### PR TITLE
chore(ci): deployer higher-level environments, merge workflow

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -18,7 +18,7 @@ on:
       environment:
         description: Environment name; omit for PRs
         required: false
-        type: environment
+        type: string
       oc_server:
         default: https://api.silver.devops.gov.bc.ca:6443
         description: 'OpenShift server'

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
     inputs:
       ### Required
+      oc_namespace:
+        description: OpenShift namespace
+        required: true
+        type: string
       release:
         description: Deployment release; usually repo-name-[PR|test|prod]
         required: true
@@ -56,9 +60,6 @@ on:
         value: ${{ jobs.deployer.outputs.triggered }}
 
     secrets:
-      oc_namespace:
-        description: OpenShift namespace
-        required: true
       oc_token:
         description: OpenShift token
         required: true
@@ -111,7 +112,7 @@ jobs:
     - run: |
         # OC Login
         oc login --token=${{ secrets.oc_token }} --server=${{ inputs.oc_server }}
-        oc project ${{ secrets.oc_namespace }} # Safeguard!
+        oc project ${{ inputs.oc_namespace }} # Safeguard!
 
     # Stop pre-existing deployments
     - run: |

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -4,10 +4,6 @@ on:
   workflow_call:
     inputs:
       ### Required
-      oc_namespace:
-        description: OpenShift namespace
-        required: true
-        type: string
       release:
         description: Deployment release; usually repo-name-[PR|test|prod]
         required: true
@@ -60,6 +56,9 @@ on:
         value: ${{ jobs.deployer.outputs.triggered }}
 
     secrets:
+      oc_namespace:
+        description: OpenShift namespace
+        required: true
       oc_token:
         description: OpenShift token
         required: true
@@ -112,7 +111,7 @@ jobs:
     - run: |
         # OC Login
         oc login --token=${{ secrets.oc_token }} --server=${{ inputs.oc_server }}
-        oc project ${{ inputs.oc_namespace }} # Safeguard!
+        oc project ${{ secrets.oc_namespace }} # Safeguard!
 
     # Stop pre-existing deployments
     - run: |

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -10,11 +10,6 @@ on:
         type: string
 
       ### Typical / recommended
-      cleanup:
-        description: Cleanup, too aggressive for higher level environments
-        default: false
-        required: false
-        type: string
       directory:
         description: Chart directory
         default:  'charts/${{ github.event.repository.name }}'
@@ -63,10 +58,10 @@ on:
     secrets:
       oc_namespace:
         description: OpenShift namespace
-        required: false
+        required: true
       oc_token:
         description: OpenShift token
-        required: false
+        required: true
 
 jobs:
   deployer:

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -20,6 +20,10 @@ on:
         default:  'charts/${{ github.event.repository.name }}'
         required: false
         type: string
+      environment:
+        description: GitHub environment; omit for DEV/PRs
+        required: false
+        type: string
       oc_server:
         default: https://api.silver.devops.gov.bc.ca:6443
         description: 'OpenShift server'
@@ -108,7 +112,8 @@ jobs:
     ### Deploy
 
     # OC Login
-    - run: |
+    - environment: ${{ inputs.environment }}
+      run: |
         # OC Login
         oc login --token=${{ secrets.oc_token }} --server=${{ inputs.oc_server }}
         oc project ${{ secrets.oc_namespace }} # Safeguard!

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -21,7 +21,7 @@ on:
         required: false
         type: string
       environment:
-        description: GitHub environment; omit for DEV/PRs
+        description: Environment name; omit for PRs
         required: false
         type: string
       oc_server:
@@ -71,6 +71,7 @@ on:
 jobs:
   deployer:
     name: Deployer
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.triggers.outputs.triggered }}
@@ -112,8 +113,7 @@ jobs:
     ### Deploy
 
     # OC Login
-    - environment: ${{ inputs.environment }}
-      run: |
+    - run: |
         # OC Login
         oc login --token=${{ secrets.oc_token }} --server=${{ inputs.oc_server }}
         oc project ${{ secrets.oc_namespace }} # Safeguard!

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -18,7 +18,7 @@ on:
       environment:
         description: Environment name; omit for PRs
         required: false
-        type: string
+        type: environment
       oc_server:
         default: https://api.silver.devops.gov.bc.ca:6443
         description: 'OpenShift server'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -32,6 +32,7 @@ jobs:
   deploy-test:
     name: Deploy (test)
     needs: [vars]
+    environment: test
     uses: ./.github/workflows/.deployer.yml
     secrets:
       oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,6 +1,7 @@
 name: Merge
 
 on:
+  pull_request:
   push:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,6 +34,7 @@ jobs:
     environment: test
     needs: [vars]
     secrets: inherit
+    uses: ./.github/workflows/.deployer.yml
     with:
       params: --set global.autoscaling=false --set Chart.name=${{ github.event.repository.name }} #--set Chart.version=${{ github.event.number }}
       release: test

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,10 +34,10 @@ jobs:
     needs: [vars]
     uses: ./.github/workflows/.deployer.yml
     secrets:
-      oc_namespace: ${{ vars.oc_namespace }}
       oc_token: ${{ secrets.oc_token }}
     with:
       environment: test
+      oc_namespace: ${{ vars.oc_namespace }}
       params: --set global.autoscaling=false
       release: test
       tag: ${{ needs.vars.outputs.pr }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -40,6 +40,5 @@ jobs:
       environment: test
       params: --set global.autoscaling=false
       release: test
-      tag: ${{ needs.vars.outputs.pr }}
 
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -31,11 +31,11 @@ jobs:
 
   deploy-test:
     name: Deploy (test)
-    environment: test
     needs: [vars]
-    secrets: inherit
     uses: ./.github/workflows/.deployer.yml
+    secrets: inherit
     with:
+      environment: test
       params: --set global.autoscaling=false --set Chart.name=${{ github.event.repository.name }} #--set Chart.version=${{ github.event.number }}
       release: test
       tag: ${{ needs.vars.outputs.pr }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,41 @@
+name: Merge
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
+      - '.github/**'
+      - '.graphics/**'
+      - '!.github/workflows/**'
+  workflow_dispatch:
+    inputs:
+      pr_no:
+        description: "PR-numbered container set to deploy"
+        type: number
+        required: true
+
+jobs:
+  vars:
+    name: Set Variables
+    outputs:
+      pr: ${{ steps.pr.outputs.pr }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
+    steps:
+      # Get PR number for squash merges to main
+      - name: PR Number
+        id: pr
+        uses: bcgov-nr/action-get-pr@v0.0.1
+
+  deploy-test:
+    name: Deploy (test)
+    environment: test
+    needs: [vars]
+    secrets: inherit
+    with:
+      params: --set global.autoscaling=false --set Chart.name=${{ github.event.repository.name }} #--set Chart.version=${{ github.event.number }}
+      release: test
+      tag: ${{ needs.vars.outputs.pr }}
+
+

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -32,13 +32,12 @@ jobs:
   deploy-test:
     name: Deploy (test)
     needs: [vars]
-    environment: test
     uses: ./.github/workflows/.deployer.yml
     secrets:
+      oc_namespace: ${{ secrets.oc_namespace }}
       oc_token: ${{ secrets.oc_token }}
     with:
       environment: test
-      oc_namespace: ${{ vars.oc_namespace }}
       params: --set global.autoscaling=false
       release: test
       tag: ${{ needs.vars.outputs.pr }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,6 @@
 name: Merge
 
 on:
-  pull_request:
   push:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,10 +33,12 @@ jobs:
     name: Deploy (test)
     needs: [vars]
     uses: ./.github/workflows/.deployer.yml
-    secrets: inherit
+    secrets:
+      oc_namespace: ${{ vars.oc_namespace }}
+      oc_token: ${{ secrets.oc_token }}
     with:
       environment: test
-      params: --set global.autoscaling=false --set Chart.name=${{ github.event.repository.name }} #--set Chart.version=${{ github.event.number }}
+      params: --set global.autoscaling=false
       release: test
       tag: ${{ needs.vars.outputs.pr }}
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,7 +1,8 @@
 name: PR
 
 on:
-  pull_request:
+  # pull_request:
+  workflow_dispatch:
 
 concurrency:
   # Cancel in progress for PR open and close

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,7 @@
 name: PR
 
 on:
-  # pull_request:
-  workflow_dispatch:
+  pull_request:
 
 concurrency:
   # Cancel in progress for PR open and close

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -43,7 +43,7 @@ jobs:
     uses: ./.github/workflows/.deployer.yml
     secrets: inherit
     with:
-      params: --set global.autoscaling=false --set Chart.name=${{ github.event.repository.name }} #--set Chart.version=${{ github.event.number }}
+      params: --set global.autoscaling=false
       release: ${{ github.event.number }}
 
   close:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,9 @@ jobs:
     name: Deploys
     needs: [builds]
     uses: ./.github/workflows/.deployer.yml
-    secrets: inherit
+    secrets:
+      oc_namespace: ${{ secrets.oc_namespace }}
+      oc_token: ${{ secrets.oc_token }}
     with:
       params: --set global.autoscaling=false
       release: ${{ github.event.number }}
@@ -50,7 +52,9 @@ jobs:
     name: Close
     needs: [deploys]
     uses: ./.github/workflows/.pr-close.yml
-    secrets: inherit
+    secrets:
+      oc_namespace: ${{ secrets.oc_namespace }}
+      oc_token: ${{ secrets.oc_token }}
     with:
       cleanup: helm
 


### PR DESCRIPTION
Merge workflow and support for higher-level environments, like TEST and PROD.  Only TEST will be used here.

UPDATE: Reusable workflows (event: workflow_call) can't currently handle environment variables, which forces us to unnecessarily use secrets.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-13-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-13-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)