### PR TITLE
chore(ci): adjust released app version for visibility

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -125,7 +125,7 @@ jobs:
       run: |
         # Package Helm chart using release name
         sed -i 's/^name:.*/name: ${{ github.event.repository.name }}/' Chart.yaml
-        helm package -u . --app-version="${{ steps.vars.outputs.tag }}-run${{ github.run_number }}" --version=${{ steps.pr.outputs.pr }}
+        helm package -u . --app-version="tag-${{ steps.vars.outputs.tag }}_run-${{ github.run_number }}" --version=${{ steps.pr.outputs.pr }}
 
     # Deploy Helm chart
     - working-directory: ${{ inputs.directory }}


### PR DESCRIPTION
New format: tag-$tag_run-$run.  E.g. `tag-123_run-456`.  Mostly being used as an excuse to test main merge workflows.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-21-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-21-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)