### PR TITLE
chore(ci): rename Deployer job to Helm for better visibility in PRs

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -62,7 +62,7 @@ on:
 
 jobs:
   deployer:
-    name: Deployer
+    name: Helm
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - id: packages
         run: |
+          # Convert packages to JSON array for job matrix
           echo "packages=$(jq -cn '$ARGS.positional' --args ${{ inputs.packages }})"
           echo "packages=$(jq -cn '$ARGS.positional' --args ${{ inputs.packages }})" >> $GITHUB_OUTPUT
 

--- a/deployer.yml
+++ b/deployer.yml
@@ -1,1 +1,0 @@
-.github/workflows/.deployer.yml

--- a/pr-close.yml
+++ b/pr-close.yml
@@ -1,1 +1,0 @@
-.github/workflows/.pr-close.yml

--- a/pr-validate.yml
+++ b/pr-validate.yml
@@ -1,1 +1,0 @@
-.github/workflows/.pr-validate.yml


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-24-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-24-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)