### PR TITLE
chore: compare before and after tags, fail as necessary

### DIFF
--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -95,6 +95,15 @@ jobs:
           target: ${{ inputs.target }}
           tags: ${{ inputs.tag_promote }}
 
+      - run: |
+          # Verify tagging
+          SOURCE=$(docker manifest inspect ghcr.io/bcgov/nr-spar/sync:${{ inputs.target }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          TARGET=$(docker manifest inspect ghcr.io/bcgov/nr-spar/sync:${{ inputs.tag_promote }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          if [ "${SOURCE}" != "${TARGET}" ]; then
+            echo "ERROR: Tagging failed!"
+            exit 1
+          fi
+
   # Clean up OpenShift when PR closed, no conditions
   cleanup:
     name: OpenShift

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -97,9 +97,9 @@ jobs:
 
       - run: |
           # Verify tagging
-          PACKAGE="ghcr.io/${{ inputs.organization }}/${{ inputs.repository }}/${{ matrix.package }}"
-          SOURCE=$(docker manifest inspect ${PACKAGE}:${{ inputs.tag_promote }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
-          TARGET=$(docker manifest inspect ${PACKAGE}:${{ inputs.target }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          INSPECT="docker manifest inspect ghcr.io/${{ inputs.organization }}/${{ inputs.repository }}/${{ matrix.package }}"
+          SOURCE=$(${INSPECT}:${{ inputs.tag_promote }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          TARGET=$(${INSPECT}:${{ inputs.target }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
           if [ "${SOURCE}" != "${TARGET}" ]; then
             echo "ERROR: Tagging failed!"
             exit 1

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -97,8 +97,9 @@ jobs:
 
       - run: |
           # Verify tagging
-          SOURCE=$(docker manifest inspect ghcr.io/bcgov/nr-spar/sync:${{ inputs.target }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
-          TARGET=$(docker manifest inspect ghcr.io/bcgov/nr-spar/sync:${{ inputs.tag_promote }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          PACKAGE="ghcr.io/${{ inputs.organization }}/${{ inputs.repository }}/${{ matrix.package }}"
+          SOURCE=$(docker manifest inspect ${PACKAGE}:${{ inputs.tag_promote }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
+          TARGET=$(docker manifest inspect ${PACKAGE}:${{ inputs.target }} | jq -r '.manifests[] | select(.platform.architecture=="amd64") | .digest')
           if [ "${SOURCE}" != "${TARGET}" ]; then
             echo "ERROR: Tagging failed!"
             exit 1


### PR DESCRIPTION
There might have been a case where image promotion failed silently.  This verifies a successful run.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-54-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-54-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)