### PR TITLE
chore: add a way to delete persisted secrets when pr is closed as helm wont delete persisted secrets.

### DIFF
--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -23,7 +23,7 @@ on:
         type: string
       remove_pvc:
         required: false
-        default: data-${{ inputs.repository }}-${{ inputs.target }}-bitnami-pg-0
+        default: data-${{ github.event.repository.name }}-${{ github.event.number }}-bitnami-pg-0
         type: string
         description: 'Comma separated list of PVCs to remove'
 

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -168,6 +168,10 @@ jobs:
           # If found, then remove
           helm status ${{ env.release }} && helm uninstall --no-hooks ${{ env.release }} || \
             echo "Not found: ${{ env.release }}"
+          
+          # Sometimes teams prefer to persist secret objects across rollouts of same PR, so the below make sure it is deleted when pr is closed.
+          oc delete secret -l app.kubernetes.io/instance=${{ env.release }} || \
+            echo "No Persisted, Secret found for: ${{ env.release }}"
       
       # Cleanup for OpenShift template deployments, uses labels
       - name: Label


### PR DESCRIPTION
Also added a small change to remove pvc after pr close.
---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-90-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-90-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-90-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-90-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)