### PR TITLE
fix(cd): helm pvc clean up after pr close

### DIFF
--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -23,7 +23,7 @@ on:
         type: string
       remove_pvc:
         required: false
-        default: data-${{ inputs.repository }}-${{ inputs.target }}-bitnami-pg-0
+        default: data-${{ github.event.repository.name }}-${{ github.event.number }}-bitnami-pg-0
         type: string
         description: 'Comma separated list of PVCs to remove'
 


### PR DESCRIPTION
currently when PR is closed the pvc are not removed.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-93-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-93-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)