### PR TITLE
chore: release name and refs

### DIFF
--- a/.github/workflows/.deployer-db.yml
+++ b/.github/workflows/.deployer-db.yml
@@ -106,7 +106,7 @@ jobs:
         id: release_name
         shell: bash
         run: |
-          RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+          RELEASE_NAME=pg-$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)
           echo "RELEASE_NAME=${RELEASE_NAME}" >> $GITHUB_OUTPUT
           echo "Release name: ${RELEASE_NAME}"
       - name: Deploy Database

--- a/.github/workflows/.deployer-db.yml
+++ b/.github/workflows/.deployer-db.yml
@@ -121,15 +121,20 @@ jobs:
                 --set-string crunchy.pgBackRest.s3.secretKey=${{ secrets.s3_secret_key }} \
                 --set-string crunchy.pgBackRest.s3.bucket=${{ secrets.s3_bucket }} \
                 --set-string crunchy.pgBackRest.s3.endpoint=${{ secrets.s3_endpoint }} \
-                --values ${{ inputs.values }} ${{github.event.repository.name}}  .
+                --set-string crunchy.postgresVersion="16" \
+                --set-string crunchy.postgisVersion="3.4" \
+                --values ${{ inputs.values }} ${{github.event.repository.name}}-postgres  .
             else
-              helm upgrade --install --wait --values ${{ inputs.values }} ${{github.event.repository.name}} .
+              helm upgrade --install --wait --values ${{ inputs.values }} \
+              --set-string crunchy.postgresVersion="16" \
+              --set-string crunchy.postgisVersion="3.4" \
+              ${{github.event.repository.name}}-postgres .
             fi
             # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
             READY=false
             for i in {1..10}; do
               # Check if the 'db' instance has at least 1 ready replica
-              if oc get PostgresCluster/${{github.event.repository.name}}-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
+              if oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
                 echo "Crunchy DB instance 'db' is ready "
                 READY=true
                 break
@@ -145,7 +150,7 @@ jobs:
             fi
 
       - name: Add PR specific user to Crunchy DB # only for PRs
-        if: github.event_name == 'pull_request'
+        if: (github.event_name == 'pull_request' && github.event.action != 'closed')
         uses: bcgov/action-oc-runner@v1.2.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
@@ -155,7 +160,7 @@ jobs:
           commands: |
             echo 'Adding PR specific user to Crunchy DB'
             NEW_USER='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
-            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-crunchy -o json | jq '.spec.users')
+            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
             echo "${CURRENT_USERS}"
 
             # check if current_users already contains the new_user
@@ -166,12 +171,12 @@ jobs:
 
             UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson NEW_USER "${NEW_USER}" '. + [$NEW_USER]')
             PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-            oc patch PostgresCluster/${{github.event.repository.name}}-crunchy --type=merge -p "${PATCH_JSON}"
+            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
 
             # wait for sometime as it takes time to create the user, query the secret and check if it is created, otherwise wait in a loop for 5 rounds
             SECRET_FOUND=false
             for i in {1..5}; do
-              if oc get secret ${{github.event.repository.name}}-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
+              if oc get secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
                 echo "Secret created"
                 SECRET_FOUND=true
                 break
@@ -182,7 +187,40 @@ jobs:
             done
 
             if [ "$SECRET_FOUND" = false ]; then
-              echo "Error: Secret ${{github.event.repository.name}}-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
+              echo "Error: Secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
               exit 1
             fi
+      - name: Remove PR specific user from Crunchy DB # only for PRs and when PR is closed
+        if: (github.event_name == 'pull_request' && github.event.action == 'closed')
+        uses: bcgov/action-oc-runner@v1.2.0
+        with:
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          oc_server: ${{ vars.oc_server }}
+          triggers: ${{ inputs.triggers }}
+          commands: |
+            # check if postgres-crunchy exists or else exit
+            oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy || exit 0
+
+            # Remove the user from the crunchy cluster yaml and apply the changes
+            USER_TO_REMOVE='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
+            
+            echo 'getting current users from crunchy'
+            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
+            echo "${CURRENT_USERS}"
+            
+            # Remove the user from the list, 
+            UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson user "${USER_TO_REMOVE}" 'map(select(. != $user))')
+
+            PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
+            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
+            
+            # get primary crunchy pod and remove the role and db
+            CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
+            
+            echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
+            # Terminate all connections to the database before trying terminate and Drop the databse and role right after
+            oc exec -it "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- bash -c "psql -U postgres -d postgres -c \"SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'app-${{ github.event.number }}' AND pid <> pg_backend_pid();\" && \psql -U postgres -d postgres -c \"DROP DATABASE \\\"app-${{ github.event.number }}\\\";\" && \psql -U postgres -d postgres -c \"DROP ROLE \\\"app-${{ github.event.number }}\\\";\""
+            echo 'database and role deleted'
+
 

--- a/.github/workflows/.deployer-db.yml
+++ b/.github/workflows/.deployer-db.yml
@@ -121,6 +121,8 @@ jobs:
           commands: |
             echo 'Deploying crunchy helm chart'
             cd ${{ inputs.directory }}
+            sed -i 's/^name:.*/name: ${{ github.event.repository.name }}/' Chart.yaml
+            helm package -u . 
             if [ ${{ inputs.s3_enabled }} == true ]; then
               helm upgrade --install --wait --set crunchy.pgBackRest.s3.enabled=true \
                 --set-string crunchy.pgBackRest.s3.accessKey=${{ secrets.s3_access_key }} \
@@ -129,12 +131,14 @@ jobs:
                 --set-string crunchy.pgBackRest.s3.endpoint=${{ secrets.s3_endpoint }} \
                 --set-string crunchy.postgresVersion="16" \
                 --set-string crunchy.postgisVersion="3.4" \
-                --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}}  .
+                --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}}  \
+                ./${{ github.event.repository.name }}-5.5.1.tgz
             else
               helm upgrade --install --wait --values ${{ inputs.values }} \
               --set-string crunchy.postgresVersion="16" \
               --set-string crunchy.postgisVersion="3.4" \
-              ${{steps.release_name.outputs.RELEASE_NAME}} .
+              ${{steps.release_name.outputs.RELEASE_NAME}} \
+              ./${{ github.event.repository.name }}-5.5.1.tgz
             fi
             # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
             READY=false

--- a/.github/workflows/.deployer-db.yml
+++ b/.github/workflows/.deployer-db.yml
@@ -8,7 +8,7 @@ on:
 
       directory:
         description: Crunchy Chart directory
-        default: 'charts/crunchy'
+        default: 'actions/crunchy/charts/crunchy'
         required: false
         type: string
       oc_server:

--- a/.github/workflows/.deployer-db.yml
+++ b/.github/workflows/.deployer-db.yml
@@ -102,7 +102,13 @@ jobs:
             echo "S3 endpoint not found"
             exit 1
           fi
-
+      - name: Release Name
+        id: release_name
+        shell: bash
+        run: |
+          RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+          echo "RELEASE_NAME=${RELEASE_NAME}" >> $GITHUB_OUTPUT
+          echo "Release name: ${RELEASE_NAME}"
       - name: Deploy Database
         uses: bcgov/action-oc-runner@v1.2.0
         with:
@@ -123,18 +129,18 @@ jobs:
                 --set-string crunchy.pgBackRest.s3.endpoint=${{ secrets.s3_endpoint }} \
                 --set-string crunchy.postgresVersion="16" \
                 --set-string crunchy.postgisVersion="3.4" \
-                --values ${{ inputs.values }} ${{github.event.repository.name}}-postgres  .
+                --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}}  .
             else
               helm upgrade --install --wait --values ${{ inputs.values }} \
               --set-string crunchy.postgresVersion="16" \
               --set-string crunchy.postgisVersion="3.4" \
-              ${{github.event.repository.name}}-postgres .
+              ${{steps.release_name.outputs.RELEASE_NAME}} .
             fi
             # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
             READY=false
             for i in {1..10}; do
               # Check if the 'db' instance has at least 1 ready replica
-              if oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
+              if oc get PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
                 echo "Crunchy DB instance 'db' is ready "
                 READY=true
                 break
@@ -160,7 +166,7 @@ jobs:
           commands: |
             echo 'Adding PR specific user to Crunchy DB'
             NEW_USER='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
-            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
+            CURRENT_USERS=$(oc get PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy -o json | jq '.spec.users')
             echo "${CURRENT_USERS}"
 
             # check if current_users already contains the new_user
@@ -171,12 +177,12 @@ jobs:
 
             UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson NEW_USER "${NEW_USER}" '. + [$NEW_USER]')
             PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
+            oc patch PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy --type=merge -p "${PATCH_JSON}"
 
             # wait for sometime as it takes time to create the user, query the secret and check if it is created, otherwise wait in a loop for 5 rounds
             SECRET_FOUND=false
             for i in {1..5}; do
-              if oc get secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
+              if oc get secret ${{steps.release_name.outputs.RELEASE_NAME}}-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
                 echo "Secret created"
                 SECRET_FOUND=true
                 break
@@ -187,40 +193,9 @@ jobs:
             done
 
             if [ "$SECRET_FOUND" = false ]; then
-              echo "Error: Secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
+              echo "Error: Secret ${{steps.release_name.outputs.RELEASE_NAME}}-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
               exit 1
             fi
-      - name: Remove PR specific user from Crunchy DB # only for PRs and when PR is closed
-        if: (github.event_name == 'pull_request' && github.event.action == 'closed')
-        uses: bcgov/action-oc-runner@v1.2.0
-        with:
-          oc_namespace: ${{ secrets.oc_namespace }}
-          oc_token: ${{ secrets.oc_token }}
-          oc_server: ${{ vars.oc_server }}
-          triggers: ${{ inputs.triggers }}
-          commands: |
-            # check if postgres-crunchy exists or else exit
-            oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy || exit 0
-
-            # Remove the user from the crunchy cluster yaml and apply the changes
-            USER_TO_REMOVE='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
-            
-            echo 'getting current users from crunchy'
-            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
-            echo "${CURRENT_USERS}"
-            
-            # Remove the user from the list, 
-            UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson user "${USER_TO_REMOVE}" 'map(select(. != $user))')
-
-            PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
-            
-            # get primary crunchy pod and remove the role and db
-            CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
-            
-            echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
-            # Terminate all connections to the database before trying terminate and Drop the databse and role right after
-            oc exec -it "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- bash -c "psql -U postgres -d postgres -c \"SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'app-${{ github.event.number }}' AND pid <> pg_backend_pid();\" && \psql -U postgres -d postgres -c \"DROP DATABASE \\\"app-${{ github.event.number }}\\\";\" && \psql -U postgres -d postgres -c \"DROP ROLE \\\"app-${{ github.event.number }}\\\";\""
-            echo 'database and role deleted'
+      
 
 

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -128,7 +128,7 @@ jobs:
             helm status ${{ env.release }} && helm uninstall --no-hooks ${{ env.release }} || \
               echo "Not found: ${{ env.release }}"
             # check if crunchy exists or else exit
-            CRUNCHY_RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+            CRUNCHY_RELEASE_NAME=pg-$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)
             oc get PostgresCluster/${CRUNCHY_RELEASE_NAME}-crunchy || exit 0
 
             # Remove the user from the crunchy cluster yaml and apply the changes

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -127,6 +127,29 @@ jobs:
             # If found, then remove
             helm status ${{ env.release }} && helm uninstall --no-hooks ${{ env.release }} || \
               echo "Not found: ${{ env.release }}"
+            # check if crunchy exists or else exit
+            oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy || exit 0
+
+            # Remove the user from the crunchy cluster yaml and apply the changes
+            USER_TO_REMOVE='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
+            
+            echo 'getting current users from crunchy'
+            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
+            echo "${CURRENT_USERS}"
+            
+            # Remove the user from the list, 
+            UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson user "${USER_TO_REMOVE}" 'map(select(. != $user))')
+
+            PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
+            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
+            
+            # get primary crunchy pod and remove the role and db
+            CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/cluster=${{github.event.repository.name}}-postgres-crunchy,postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
+            
+            echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
+            # Terminate all connections to the database before trying terminate and Drop the databse and role right after
+            oc exec -it "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- bash -c "psql -U postgres -d postgres -c \"SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'app-${{ github.event.number }}' AND pid <> pg_backend_pid();\" && \psql -U postgres -d postgres -c \"DROP DATABASE \\\"app-${{ github.event.number }}\\\";\" && \psql -U postgres -d postgres -c \"DROP ROLE \\\"app-${{ github.event.number }}\\\";\""
+            echo 'database and role deleted'
       
       - name: OC Template (label) Cleanup
         if: inputs.cleanup == 'label'

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -135,7 +135,7 @@ jobs:
             USER_TO_REMOVE='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
             
             echo 'getting current users from crunchy'
-            CURRENT_USERS=$(oc get PostgresCluster/${CRUNCHY_RELEASE_NAME}-postgres-crunchy -o json | jq '.spec.users')
+            CURRENT_USERS=$(oc get PostgresCluster/${CRUNCHY_RELEASE_NAME}-crunchy -o json | jq '.spec.users')
             echo "${CURRENT_USERS}"
             
             # Remove the user from the list, 

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -128,23 +128,24 @@ jobs:
             helm status ${{ env.release }} && helm uninstall --no-hooks ${{ env.release }} || \
               echo "Not found: ${{ env.release }}"
             # check if crunchy exists or else exit
-            oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy || exit 0
+            CRUNCHY_RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+            oc get PostgresCluster/${CRUNCHY_RELEASE_NAME}-crunchy || exit 0
 
             # Remove the user from the crunchy cluster yaml and apply the changes
             USER_TO_REMOVE='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
             
             echo 'getting current users from crunchy'
-            CURRENT_USERS=$(oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq '.spec.users')
+            CURRENT_USERS=$(oc get PostgresCluster/${CRUNCHY_RELEASE_NAME}-postgres-crunchy -o json | jq '.spec.users')
             echo "${CURRENT_USERS}"
             
             # Remove the user from the list, 
             UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson user "${USER_TO_REMOVE}" 'map(select(. != $user))')
 
             PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-            oc patch PostgresCluster/${{github.event.repository.name}}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
+            oc patch PostgresCluster/${CRUNCHY_RELEASE_NAME}-crunchy --type=merge -p "${PATCH_JSON}"
             
             # get primary crunchy pod and remove the role and db
-            CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/cluster=${{github.event.repository.name}}-postgres-crunchy,postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
+            CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/cluster=${CRUNCHY_RELEASE_NAME}-crunchy,postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
             
             echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
             # Terminate all connections to the database before trying terminate and Drop the databse and role right after

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -149,7 +149,7 @@ jobs:
             
             echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
             # Terminate all connections to the database before trying terminate and Drop the databse and role right after
-            oc exec -it "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- bash -c "psql -U postgres -d postgres -c \"SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'app-${{ github.event.number }}' AND pid <> pg_backend_pid();\" && psql -U postgres -d postgres -c \"DROP DATABASE 'app-${{ github.event.number }}';\" && psql -U postgres -d postgres -c \"DROP ROLE 'app-${{ github.event.number }}';\""
+            oc exec -it "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- bash -c "psql -U postgres -d postgres -c \"SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'app-${{ github.event.number }}' AND pid <> pg_backend_pid();\" && \psql -U postgres -d postgres -c \"DROP DATABASE \\\"app-${{ github.event.number }}\\\";\" && \psql -U postgres -d postgres -c \"DROP ROLE \\\"app-${{ github.event.number }}\\\";\""
             echo 'database and role deleted'
       
       - name: OC Template (label) Cleanup

--- a/actions/crunchy/action.yml
+++ b/actions/crunchy/action.yml
@@ -50,7 +50,13 @@ inputs:
   s3_endpoint:
     description: 'S3 endpoint'
     required: false
-
+  postgres_version:
+    description: 'Postgres version to use; e.g. 16, 15, Must check with platform team for supported versions'
+    required: true
+  postgis_version:
+    description: 'PostGIS version to use; e.g. 3.4, 3.3, 3.2'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -95,15 +101,20 @@ runs:
               --set-string crunchy.pgBackRest.s3.secretKey=${{ inputs.s3_secret_key }} \
               --set-string crunchy.pgBackRest.s3.bucket=${{ inputs.s3_bucket }} \
               --set-string crunchy.pgBackRest.s3.endpoint=${{ inputs.s3_endpoint }} \
-              --values ${{ inputs.values }} ${{ github.event.repository.name }}  .
+              --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
+              --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
+              --values ${{ inputs.values }} ${{ github.event.repository.name }}-postgres  .
           else
-            helm upgrade --install --wait --values ${{ inputs.values }} ${{ github.event.repository.name }} .
+            helm upgrade --install --wait --values ${{ inputs.values }} \
+            --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
+            --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
+            ${{ github.event.repository.name }}-postgres .
           fi
           # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
           READY=false
           for i in {1..10}; do
             # Check if the 'db' instance has at least 1 ready replica
-            if oc get PostgresCluster/${{github.event.repository.name}}-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
+            if oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
               echo "Crunchy DB instance 'db' is ready "
               READY=true
               break
@@ -129,7 +140,7 @@ runs:
         commands: |
           echo 'Adding PR specific user to Crunchy DB'
           NEW_USER='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
-          CURRENT_USERS=$(oc get PostgresCluster/${{ github.event.repository.name }}-crunchy -o json | jq '.spec.users')
+          CURRENT_USERS=$(oc get PostgresCluster/${{ github.event.repository.name }}-postgres-crunchy -o json | jq '.spec.users')
           echo "${CURRENT_USERS}"
 
           # check if current_users already contains the new_user
@@ -140,11 +151,11 @@ runs:
 
           UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson NEW_USER "${NEW_USER}" '. + [$NEW_USER]')
           PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-          oc patch PostgresCluster/${{ github.event.repository.name }}-crunchy --type=merge -p "${PATCH_JSON}"
+          oc patch PostgresCluster/${{ github.event.repository.name }}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
           # wait for sometime as it takes time to create the user, query the secret and check if it is created, otherwise wait in a loop for 5 rounds
           SECRET_FOUND=false
           for i in {1..5}; do
-            if oc get secret ${{github.event.repository.name}}-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
+            if oc get secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
               echo "Secret created"
               SECRET_FOUND=true
               break
@@ -155,6 +166,6 @@ runs:
           done
 
           if [ "$SECRET_FOUND" = false ]; then
-            echo "Error: Secret ${{github.event.repository.name}}-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
+            echo "Error: Secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
             exit 1
           fi

--- a/actions/crunchy/action.yml
+++ b/actions/crunchy/action.yml
@@ -4,7 +4,7 @@ description: 'Deploy a Crunchy PostgreSQL database to OpenShift'
 inputs:
   directory:
     description: 'Crunchy Chart directory'
-    default: 'charts/crunchy'
+    default: 'actions/crunchy/charts/crunchy'
     required: false
   oc_server:
     description: 'OpenShift server'

--- a/actions/crunchy/action.yml
+++ b/actions/crunchy/action.yml
@@ -102,6 +102,8 @@ runs:
         commands: |
           echo 'Deploying crunchy helm chart'
           cd ${{ inputs.directory }}
+          sed -i 's/^name:.*/name: ${{ github.event.repository.name }}/' Chart.yaml
+          helm package -u .
           if [ "${{ inputs.s3_enabled }}" == "true" ]; then
             helm upgrade --install --wait --set crunchy.pgBackRest.s3.enabled=true \
               --set-string crunchy.pgBackRest.s3.accessKey=${{ inputs.s3_access_key }} \
@@ -110,12 +112,14 @@ runs:
               --set-string crunchy.pgBackRest.s3.endpoint=${{ inputs.s3_endpoint }} \
               --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
               --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
-              --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}}  .
+              --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}} \
+              ./${{ github.event.repository.name }}-5.5.1.tgz
           else
             helm upgrade --install --wait --values ${{ inputs.values }} \
             --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
             --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
-            ${{steps.release_name.outputs.RELEASE_NAME}}  .
+            ${{steps.release_name.outputs.RELEASE_NAME}} \
+            ./${{ github.event.repository.name }}-5.5.1.tgz
           fi
           # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
           READY=false

--- a/actions/crunchy/action.yml
+++ b/actions/crunchy/action.yml
@@ -87,7 +87,7 @@ runs:
       id: release_name
       shell: bash
       run: |
-        RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+        RELEASE_NAME=pg-$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)
         echo "RELEASE_NAME=${RELEASE_NAME}" >> $GITHUB_OUTPUT
         echo "Release name: ${RELEASE_NAME}"
     - name: Deploy Database

--- a/actions/crunchy/action.yml
+++ b/actions/crunchy/action.yml
@@ -83,6 +83,13 @@ runs:
         fi
 
     - uses: actions/checkout@v4
+    - name: Release Name
+      id: release_name
+      shell: bash
+      run: |
+        RELEASE_NAME=$(echo -n "${{github.event.repository.name}}" | md5sum | cut -c 1-8)-postgres
+        echo "RELEASE_NAME=${RELEASE_NAME}" >> $GITHUB_OUTPUT
+        echo "Release name: ${RELEASE_NAME}"
     - name: Deploy Database
       uses: bcgov/action-oc-runner@v1.2.0
       with:
@@ -103,18 +110,18 @@ runs:
               --set-string crunchy.pgBackRest.s3.endpoint=${{ inputs.s3_endpoint }} \
               --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
               --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
-              --values ${{ inputs.values }} ${{ github.event.repository.name }}-postgres  .
+              --values ${{ inputs.values }} ${{steps.release_name.outputs.RELEASE_NAME}}  .
           else
             helm upgrade --install --wait --values ${{ inputs.values }} \
             --set-string crunchy.postgresVersion=${{ inputs.postgres_version }} \
             --set-string crunchy.postgisVersion=${{ inputs.postgis_version }} \
-            ${{ github.event.repository.name }}-postgres .
+            ${{steps.release_name.outputs.RELEASE_NAME}}  .
           fi
           # check if operator deployed the db successfully, retry 10 times with 60 seconds interval
           READY=false
           for i in {1..10}; do
             # Check if the 'db' instance has at least 1 ready replica
-            if oc get PostgresCluster/${{github.event.repository.name}}-postgres-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
+            if oc get PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy -o json | jq -e '.status.instances[] | select(.name=="db") | .readyReplicas > 0' > /dev/null 2>&1; then
               echo "Crunchy DB instance 'db' is ready "
               READY=true
               break
@@ -140,7 +147,7 @@ runs:
         commands: |
           echo 'Adding PR specific user to Crunchy DB'
           NEW_USER='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'
-          CURRENT_USERS=$(oc get PostgresCluster/${{ github.event.repository.name }}-postgres-crunchy -o json | jq '.spec.users')
+          CURRENT_USERS=$(oc get PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy -o json | jq '.spec.users')
           echo "${CURRENT_USERS}"
 
           # check if current_users already contains the new_user
@@ -151,11 +158,11 @@ runs:
 
           UPDATED_USERS=$(echo "${CURRENT_USERS}" | jq --argjson NEW_USER "${NEW_USER}" '. + [$NEW_USER]')
           PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
-          oc patch PostgresCluster/${{ github.event.repository.name }}-postgres-crunchy --type=merge -p "${PATCH_JSON}"
+          oc patch PostgresCluster/${{steps.release_name.outputs.RELEASE_NAME}}-crunchy --type=merge -p "${PATCH_JSON}"
           # wait for sometime as it takes time to create the user, query the secret and check if it is created, otherwise wait in a loop for 5 rounds
           SECRET_FOUND=false
           for i in {1..5}; do
-            if oc get secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
+            if oc get secret ${{steps.release_name.outputs.RELEASE_NAME}}-crunchy-pguser-app-${{ github.event.number }} -o jsonpath='{.metadata.name}' > /dev/null 2>&1; then
               echo "Secret created"
               SECRET_FOUND=true
               break
@@ -166,6 +173,6 @@ runs:
           done
 
           if [ "$SECRET_FOUND" = false ]; then
-            echo "Error: Secret ${{github.event.repository.name}}-postgres-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
+            echo "Error: Secret ${{steps.release_name.outputs.RELEASE_NAME}}-crunchy-pguser-app-${{ github.event.number }} was not created after 5 attempts."
             exit 1
           fi

--- a/actions/crunchy/charts/crunchy/values.yaml
+++ b/actions/crunchy/charts/crunchy/values.yaml
@@ -3,8 +3,8 @@ global:
     dbName: app #test
 crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single postgres
   enabled: true
-  postgresVersion: 16
-  postGISVersion: '3.4'
+  postgresVersion: ~
+  postGISVersion: ~
   imagePullPolicy: IfNotPresent
   # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
   # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/


### PR DESCRIPTION
- Improve Helm release name to specify when PostGIS is used
- Clean up database user on PR close

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-147-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-147-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)