### PR TITLE
fix: default not allowed for secret

### DIFF
--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -61,8 +61,7 @@ on:
         description: 'OpenShift token'
         required: false
       oc_server:
-        default: https://api.silver.devops.gov.bc.ca:6443
-        description: 'OpenShift server'
+        description: 'OpenShift server, defaults to https://api.silver.devops.gov.bc.ca:6443'
         required: false
 
 permissions: {}


### PR DESCRIPTION
Defaults aren't allowed in secrets, so this PR provides a fallback value for oc_namespace anyway.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-173-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-173-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)