### PR TITLE
feat: rename_deployment.sh, db_transfer.sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       oc_server: ${{ secrets.OC_SERVER }}   # REMOVED - OPTIONAL!
 ```
 
-# oc_scripts
+# ./oc_scripts
 
 `rename_deployment.sh` - rename a deployment (metadata, labels)
 `db_transfer.sh` - stream pg_dump from one container to pg_restore in another

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Merge](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml/badge.svg)](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)
-[![PR Closed](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/pr-close.yml/badge.svg)](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/pr-close.yml)
 
 # QuickStart OpenShift - Helpers
 Workflows and any other common code used by bcgov/quickstart-openshift (template).
@@ -25,3 +24,8 @@ jobs:
       packages: backend client migrations
       oc_server: ${{ secrets.OC_SERVER }}   # REMOVED - OPTIONAL!
 ```
+
+# oc_scripts
+
+rename_deployment.sh - rename a deployment (metadata, labels)
+db_transfer.sh - stream pg_dump from one container to pg_restore in another

--- a/README.md
+++ b/README.md
@@ -27,5 +27,23 @@ jobs:
 
 # oc_scripts
 
-rename_deployment.sh - rename a deployment (metadata, labels)
-db_transfer.sh - stream pg_dump from one container to pg_restore in another
+`rename_deployment.sh` - rename a deployment (metadata, labels)
+`db_transfer.sh` - stream pg_dump from one container to pg_restore in another
+
+These scripts can be used to migrate a postgres database.
+```
+# 1. Scale down stack
+# Use web console
+
+# 2. Rename the old db
+./rename_deployment.sh fom-test-db
+
+# 3. Deploy the new db
+oc process -f openshift.deploy.yml -p ZONE=test -p TAG=test | oc apply -f -
+
+# 4. Stream dump from old to new db
+./db_transfer.sh fom-test-db fom-test-db-prev
+
+# 5. Scale up stack
+# Use web console
+```

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -41,7 +41,7 @@ fi
 
 # Stream dump directly from old deployment to new deployment
 echo "Database transfer from '${OLD_DEPLOYMENT}' to '${NEW_DEPLOYMENT}' beginning."
-oc exec -i deployment/"${OLD_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc \"${DUMP_PARAMETERS}\"" \
+oc exec -i deployment/"${OLD_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc ${DUMP_PARAMETERS[@]}" \
   | oc exec -i deployment/"${NEW_DEPLOYMENT}" -- bash -c "pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc"
 
 # Results

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Database Transfer Script for OpenShift
+# Usage:
+#   ./db_transfer.sh <old-deployment-name> <new-deployment-name>
+#
+# This script takes a PostgreSQL database dump from the OLD_DEPLOYMENT and restores it into the NEW_DEPLOYMENT.
+# Requirements:
+# - Both deployments must have running pods managed by the given deployment names.
+# - The database template should use a PersistentVolumeClaim with a different name for the new deployment.
+# - The new deployment should be ready to accept a restore.
+# - The script assumes the container name is the default or the first in the pod spec.
+#
+# Notes:
+# - If the target database is not empty, you may see errors like "schema ... already exists".
+#   These are expected if objects already exist and can usually be ignored, but always review
+#   the output for unexpected or critical errors.
+
+# Strict mode: exit on error, unset vars, or failed pipes
+set -euo pipefail
+
+# Usage
+if [[ $# -lt 2 ]]; then
+  grep -v '^#!' "$0" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
+  exit 1
+fi
+
+OLD_DEPLOYMENT="${1}"
+NEW_DEPLOYMENT="${2}"
+DUMP_PARAMETERS="${DUMP_PARAMETERS:---exclude-schema=tiger --exclude-schema=tiger_data --exclude-schema=topology}"
+
+# Fail fast if pods aren't found
+if ! oc get po -l deployment="${OLD_DEPLOYMENT}" | grep -q '^'; then
+  echo "No pods found for deployment '${OLD_DEPLOYMENT}'."
+  exit 2
+fi
+if ! oc get po -l deployment="${NEW_DEPLOYMENT}" | grep -q '^'; then
+  echo "No pods found for deployment '${NEW_DEPLOYMENT}'."
+  exit 2
+fi
+
+# Stream dump directly from old deployment to new deployment
+echo "Database transfer from '${OLD_DEPLOYMENT}' to '${NEW_DEPLOYMENT}' beginning."
+oc exec -i deployment/"${OLD_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc ${DUMP_PARAMETERS}" \
+  | oc exec -i deployment/"${NEW_DEPLOYMENT}" -- bash -c "pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc"
+
+# Results
+echo -e "\nDatabase transfer from '${OLD_DEPLOYMENT}' to '${NEW_DEPLOYMENT}' complete."

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -41,7 +41,7 @@ fi
 
 # Stream dump directly from old deployment to new deployment
 echo "Database transfer from '${OLD_DEPLOYMENT}' to '${NEW_DEPLOYMENT}' beginning."
-oc exec -i deployment/"${OLD_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc ${DUMP_PARAMETERS}" \
+oc exec -i deployment/"${OLD_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc \"${DUMP_PARAMETERS}\"" \
   | oc exec -i deployment/"${NEW_DEPLOYMENT}" -- bash -c "pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc"
 
 # Results

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -30,11 +30,11 @@ NEW_DEPLOYMENT="${2}"
 DUMP_PARAMETERS="${DUMP_PARAMETERS:---exclude-schema=tiger --exclude-schema=tiger_data --exclude-schema=topology}"
 
 # Fail fast if pods aren't found
-if ! oc get po -l deployment="${OLD_DEPLOYMENT}" | grep -q '^'; then
+if ! oc get po -l deployment="${OLD_DEPLOYMENT}" | grep -q .; then
   echo "No pods found for deployment '${OLD_DEPLOYMENT}'."
   exit 2
 fi
-if ! oc get po -l deployment="${NEW_DEPLOYMENT}" | grep -q '^'; then
+if ! oc get po -l deployment="${NEW_DEPLOYMENT}" | grep -q .; then
   echo "No pods found for deployment '${NEW_DEPLOYMENT}'."
   exit 2
 fi

--- a/oc_scripts/rename_deployment.sh
+++ b/oc_scripts/rename_deployment.sh
@@ -20,6 +20,7 @@ fi
 OLD_DEPLOYMENT="${1}"
 NEW_DEPLOYMENT="${2:-${OLD_DEPLOYMENT}-prev}"
 MANIFEST=$(mktemp "/tmp/${OLD_DEPLOYMENT}_$(date +%Y%m%d)_XXXXXX.json")
+trap 'rm -f "$MANIFEST"' EXIT
 
 # Fail fast if the new deployment already exists
 if oc get deployment "${NEW_DEPLOYMENT}" &>/dev/null; then

--- a/oc_scripts/rename_deployment.sh
+++ b/oc_scripts/rename_deployment.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # Usage:
-#   ./rename_deployment.sh <old-deployment-name> [new-deployment-name]
+#   ./rename_deployment.sh <source-deployment-name> [target-deployment-name]
 #
-# If [new-deployment-name] is not provided, defaults to <old-deployment-name>-prev
+# If [target-deployment-name] is not provided, defaults to <source-deployment-name>-prev
 #
 # This script renames an OpenShift deployment by exporting its manifest, updating the name,
 # deleting the old deployment, and applying the new one.
@@ -17,25 +17,25 @@ if [[ $# -lt 1 ]]; then
   exit 1
 fi
 
-OLD_DEPLOYMENT="${1}"
-NEW_DEPLOYMENT="${2:-${OLD_DEPLOYMENT}-prev}"
-MANIFEST=$(mktemp "/tmp/${OLD_DEPLOYMENT}_$(date +%Y%m%d)_XXXXXX.json")
+SOURCE_DEPLOYMENT="${1}"
+TARGET_DEPLOYMENT="${2:-${SOURCE_DEPLOYMENT}-prev}"
+MANIFEST=$(mktemp "/tmp/${SOURCE_DEPLOYMENT}_$(date +%Y%m%d)_XXXXXX.json")
 trap 'rm -f "${MANIFEST}"' EXIT
 
 # Fail fast if the new deployment already exists
-if oc get deployment "${NEW_DEPLOYMENT}" &>/dev/null; then
-  echo "Deployment '${NEW_DEPLOYMENT}' already exists. Aborting to avoid overwrite."
+if oc get deployment "${TARGET_DEPLOYMENT}" &>/dev/null; then
+  echo "Deployment '${TARGET_DEPLOYMENT}' already exists. Aborting to avoid overwrite."
   exit 2
 fi
 
 # Check if the old deployment exists
-if ! oc get deployment "${OLD_DEPLOYMENT}" &>/dev/null; then
-  echo "Deployment '${OLD_DEPLOYMENT}' not found."
+if ! oc get deployment "${SOURCE_DEPLOYMENT}" &>/dev/null; then
+  echo "Deployment '${SOURCE_DEPLOYMENT}' not found."
   exit 0
 fi
 
 # Export, clean, and update deployment manifest
-oc get deployment "${OLD_DEPLOYMENT}" -o json \
+oc get deployment "${SOURCE_DEPLOYMENT}" -o json \
   | jq 'del(
       .metadata.uid,
       .metadata.resourceVersion,
@@ -45,24 +45,24 @@ oc get deployment "${OLD_DEPLOYMENT}" -o json \
       .metadata.managedFields,
       .status
     )
-    | .metadata.name = "'"${NEW_DEPLOYMENT}"'"
-    | .spec.selector.matchLabels.deployment = "'"${NEW_DEPLOYMENT}"'"
-    | .spec.template.metadata.labels.deployment = "'"${NEW_DEPLOYMENT}"'"' \
+    | .metadata.name = "'"${TARGET_DEPLOYMENT}"'"
+    | .spec.selector.matchLabels.deployment = "'"${TARGET_DEPLOYMENT}"'"
+    | .spec.template.metadata.labels.deployment = "'"${TARGET_DEPLOYMENT}"'"' \
   > "${MANIFEST}"
 
 # Delete the old deployment and apply the new one
-oc delete deployment "${OLD_DEPLOYMENT}"
+oc delete deployment "${SOURCE_DEPLOYMENT}"
 oc apply -f "${MANIFEST}"
 
 # Clean up
 
 # Wait for the new deployment to become available
-echo "Waiting for deployment '${NEW_DEPLOYMENT}' to become available..."
-if ! oc rollout status deployment/"${NEW_DEPLOYMENT}" --timeout=120s; then
-  echo "Error: Deployment '${NEW_DEPLOYMENT}' did not become available in time."
+echo "Waiting for deployment '${TARGET_DEPLOYMENT}' to become available..."
+if ! oc rollout status deployment/"${TARGET_DEPLOYMENT}" --timeout=120s; then
+  echo "Error: Deployment '${TARGET_DEPLOYMENT}' did not become available in time."
   exit 3
 fi
 
 # Show matching deployments for confirmation
 echo -e "\nMatching deployments after renaming:"
-oc get deployments -o name | grep -iE "^deployment\.apps/(${OLD_DEPLOYMENT}|${NEW_DEPLOYMENT})$"
+oc get deployments -o name | grep -iE "^deployment\.apps/(${SOURCE_DEPLOYMENT}|${TARGET_DEPLOYMENT})$"

--- a/oc_scripts/rename_deployment.sh
+++ b/oc_scripts/rename_deployment.sh
@@ -13,14 +13,14 @@ set -euo pipefail
 
 # Show usage from header if not enough arguments
 if [[ $# -lt 1 ]]; then
-  grep -v '^#!' "$0" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
+  grep -v '^#!' "${0}" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
   exit 1
 fi
 
 OLD_DEPLOYMENT="${1}"
 NEW_DEPLOYMENT="${2:-${OLD_DEPLOYMENT}-prev}"
 MANIFEST=$(mktemp "/tmp/${OLD_DEPLOYMENT}_$(date +%Y%m%d)_XXXXXX.json")
-trap 'rm -f "$MANIFEST"' EXIT
+trap 'rm -f "${MANIFEST}"' EXIT
 
 # Fail fast if the new deployment already exists
 if oc get deployment "${NEW_DEPLOYMENT}" &>/dev/null; then

--- a/oc_scripts/rename_deployment.sh
+++ b/oc_scripts/rename_deployment.sh
@@ -55,7 +55,6 @@ oc delete deployment "${OLD_DEPLOYMENT}"
 oc apply -f "${MANIFEST}"
 
 # Clean up
-rm -f "${MANIFEST}"
 
 # Wait for the new deployment to become available
 echo "Waiting for deployment '${NEW_DEPLOYMENT}' to become available..."

--- a/oc_scripts/rename_deployment.sh
+++ b/oc_scripts/rename_deployment.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Usage:
+#   ./rename_deployment.sh <old-deployment-name> [new-deployment-name]
+#
+# If [new-deployment-name] is not provided, defaults to <old-deployment-name>-prev
+#
+# This script renames an OpenShift deployment by exporting its manifest, updating the name,
+# deleting the old deployment, and applying the new one.
+
+# Strict mode: exit on error, unset vars, or failed pipes
+set -euo pipefail
+
+# Show usage from header if not enough arguments
+if [[ $# -lt 1 ]]; then
+  grep -v '^#!' "$0" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
+  exit 1
+fi
+
+OLD_DEPLOYMENT="${1}"
+NEW_DEPLOYMENT="${2:-${OLD_DEPLOYMENT}-prev}"
+MANIFEST=$(mktemp "/tmp/${OLD_DEPLOYMENT}_$(date +%Y%m%d)_XXXXXX.json")
+
+# Fail fast if the new deployment already exists
+if oc get deployment "${NEW_DEPLOYMENT}" &>/dev/null; then
+  echo "Deployment '${NEW_DEPLOYMENT}' already exists. Aborting to avoid overwrite."
+  exit 2
+fi
+
+# Check if the old deployment exists
+if ! oc get deployment "${OLD_DEPLOYMENT}" &>/dev/null; then
+  echo "Deployment '${OLD_DEPLOYMENT}' not found."
+  exit 0
+fi
+
+# Export, clean, and update deployment manifest
+oc get deployment "${OLD_DEPLOYMENT}" -o json \
+  | jq 'del(
+      .metadata.uid,
+      .metadata.resourceVersion,
+      .metadata.selfLink,
+      .metadata.creationTimestamp,
+      .metadata.generation,
+      .metadata.managedFields,
+      .status
+    )
+    | .metadata.name = "'"${NEW_DEPLOYMENT}"'"
+    | .spec.selector.matchLabels.deployment = "'"${NEW_DEPLOYMENT}"'"
+    | .spec.template.metadata.labels.deployment = "'"${NEW_DEPLOYMENT}"'"' \
+  > "${MANIFEST}"
+
+# Delete the old deployment and apply the new one
+oc delete deployment "${OLD_DEPLOYMENT}"
+oc apply -f "${MANIFEST}"
+
+# Clean up
+rm -f "${MANIFEST}"
+
+# Wait for the new deployment to become available
+echo "Waiting for deployment '${NEW_DEPLOYMENT}' to become available..."
+if ! oc rollout status deployment/"${NEW_DEPLOYMENT}" --timeout=120s; then
+  echo "Error: Deployment '${NEW_DEPLOYMENT}' did not become available in time."
+  exit 3
+fi
+
+# Show matching deployments for confirmation
+echo -e "\nMatching deployments after renaming:"
+oc get deployments -o name | grep -iE "^deployment\.apps/(${OLD_DEPLOYMENT}|${NEW_DEPLOYMENT})$"


### PR DESCRIPTION
Originally created for [nr-fom postgres migrations](https://github.com/bcgov/nr-fom/pull/819).

`./rename_deployment.sh <source-deployment-name> [target-deployment-name]`
- exports a deployment manifest
- deletes fields (status, some metadata)
- modifies deployment (name, labels)
- redeploys the renamed deployment
- watches rollout to completion/failure
- deletes the old deployment, maintains its pvc

`./db_transfer.sh <source-deployment-name> <target-deployment-name>`
- verifies that source PVC is older than destination PVC (allows override)
- streams pg_dump to pr_restore between postgres containers
- excludes postgis schemas (tiger, tiger_data, topology)

Steps:
```
# 1. Scale down stack
# Use web console

# 2. Rename the old db
./rename_deployment.sh fom-test-db

# 3. Deploy the new db
oc process -f openshift.deploy.yml -p ZONE=test -p TAG=test | oc apply -f -

# 4. Stream dump from old to new db
./db_transfer.sh fom-test-db-prev fom-test-db

# 5. Scale up stack
# Use web console
```

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-175-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-175-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)