### PR TITLE
feat: db_compare.sh for postgres table counts

### DIFF
--- a/oc_scripts/db_compare.sh
+++ b/oc_scripts/db_compare.sh
@@ -42,6 +42,7 @@ if ! oc get po -l deployment="${TARGET_DEPLOYMENT}" --no-headers -o name | grep 
 fi
 
 # Query to get table names and row counts
+# Note: n_live_tup is an estimate, not exact count (based on statistics)
 COUNT_QUERY="
 SELECT schemaname || '.' || relname AS table_name, n_live_tup AS row_count
 FROM pg_stat_user_tables
@@ -94,5 +95,5 @@ else
   echo "❌ Differences found:"
   # Show differences without context
   echo "Changed tables:"
-  echo "$DIFF_OUTPUT" | grep '^[+-]' | grep -v '^+++\|^---'
+  echo "$DIFF_OUTPUT" | grep -E '^[+-][^+-]'
 fi


### PR DESCRIPTION
## Summary

Adds a new script `oc_scripts/db_compare.sh` to compare PostgreSQL table row counts between two OpenShift deployments.

## Features
- Takes two deployment names as arguments
- Queries `pg_stat_user_tables` for table names and row counts
- Displays first 20 tables from each database with totals
- Shows only changed tables when differences exist

## Usage
```bash
./db_compare.sh <source-deployment-name> <target-deployment-name>
```

## Example Output

### Match:
```
--- Comparison Result ---
✅ 56 tables match 56 tables
```

### With differences:
```
--- Comparison Result ---
❌ Differences found:
Changed tables:
-public.migration_main|18
+public.migration_main|17
```

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-214-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-214-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)