### PR TITLE
docs: add db_compare.sh to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ jobs:
 
 `db_transfer.sh` - stream pg_dump from one container to pg_restore in another
 
+`db_compare.sh` - compare PostgreSQL table row counts between two deployments
+
 ## Example: Postgres Database Migration
 
 These scripts can be used to migrate a postgres or postgis database.


### PR DESCRIPTION
## Summary

Adds db_compare.sh to the README documentation alongside db_transfer.sh.

## Changes

- Added db_compare.sh script description to the oc_scripts section in README.md

## Why

The db_compare.sh script (PR #214) compares PostgreSQL table row counts between two OpenShift deployments. Documentation was needed to make users aware of this tool.