### PR TITLE
fix(ci): support private repos

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -95,7 +95,7 @@ jobs:
       # Variables
       - if: inputs.tag  == ''
         id: pr
-        uses: bcgov/action-get-pr@fix/explicit-token-checkout
+        uses: bcgov/action-get-pr@1faf651ec9c8a01e8157e62aa6a904578a8783c4 #v0.2.0
 
       - name: Vars
         id: vars

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -141,39 +141,6 @@ jobs:
                 helm uninstall ${{ steps.vars.outputs.release }}
             fi
 
-      # - name: Deploy Helm chart
-      #   id: deploy
-      #   uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
-      #   with:
-      #     oc_namespace: ${{ secrets.oc_namespace }}
-      #     oc_token: ${{ secrets.oc_token }}
-      #     oc_server: ${{ inputs.oc_server }}
-      #     repository: ${{ inputs.repository }}
-      #     triggers: ${{ inputs.triggers }}
-      #     commands: |
-      #       # Package Helm chart
-      #       cd ${{ inputs.directory }}
-      #       sed -i 's/^name:.*/name: ${{ github.event.repository.name }}/' Chart.yaml
-      #       helm package -u . --app-version="tag-${{ steps.vars.outputs.tag }}_run-${{ github.run_number }}" \
-      #         --version=${{ steps.pr.outputs.pr || steps.vars.outputs.version }}
-
-      #       # Helm upgrade/rollout
-      #       helm upgrade \
-      #         --set-string global.repository=${{ github.repository }} \
-      #         --set-string global.tag=${{ steps.vars.outputs.tag }} \
-      #         ${{ inputs.params }} \
-      #         --install --wait ${{ inputs.atomic == 'true' && '--atomic' || ''}} \
-      #         ${{ steps.vars.outputs.release }} \
-      #         --timeout ${{ inputs.timeout-minutes }}m \
-      #         --values ${{ inputs.values }} \
-      #         ./${{ github.event.repository.name }}-${{ steps.pr.outputs.pr || steps.vars.outputs.version }}.tgz
-
-      #       # Helm release history
-      #       helm history ${{ steps.vars.outputs.release }}
-
-      #       # Completed pod cleanup
-      #       oc delete po --field-selector=status.phase==Succeeded || true
-
   promote:
     name: Promote Images
     if: inputs.promote_images != '' && inputs.promote_tags != ''

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -125,7 +125,7 @@ jobs:
       ### Deploy
       - name: Interrupt deployments (PR only)
         if: github.event_name == 'pull_request'
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -143,7 +143,7 @@ jobs:
 
       # - name: Deploy Helm chart
       #   id: deploy
-      #   uses: bcgov/action-oc-runner@v1.0.0
+      #   uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
       #   with:
       #     oc_namespace: ${{ secrets.oc_namespace }}
       #     oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -80,8 +80,6 @@ on:
         description: OpenShift token
         required: true
 
-permissions: {}
-
 jobs:
   deploy:
     name: Helm

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -95,7 +95,7 @@ jobs:
       # Variables
       - if: inputs.tag  == ''
         id: pr
-        uses: bcgov/action-get-pr@bfa713a9ab410c0f0c13126c35983934fc80d15b # v0.1.1
+        uses: bcgov/action-get-pr@fix/explicit-token-checkout
 
       - name: Vars
         id: vars
@@ -125,7 +125,7 @@ jobs:
       ### Deploy
       - name: Interrupt deployments (PR only)
         if: github.event_name == 'pull_request'
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           release: ${{ inputs.repository }}-${{ inputs.target }}
         if: inputs.cleanup == 'helm'
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: OC Template (label) Cleanup
         if: inputs.cleanup == 'label'
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Remove PVCs
         if: inputs.remove_pvc
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           release: ${{ inputs.repository }}-${{ inputs.target }}
         if: inputs.cleanup == 'helm'
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: OC Template (label) Cleanup
         if: inputs.cleanup == 'label'
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Remove PVCs
         if: inputs.remove_pvc
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -64,8 +64,6 @@ on:
         description: "OpenShift server, defaults to https://api.silver.devops.gov.bc.ca:6443"
         required: false
 
-permissions: {}
-
 env:
   DEFAULT_OC_SERVER: https://api.silver.devops.gov.bc.ca:6443
 

--- a/.github/workflows/.pr-validate.yml
+++ b/.github/workflows/.pr-validate.yml
@@ -19,8 +19,6 @@ on:
         required: false
         type: string
 
-permissions: {}
-
 jobs:
   checks:
     name: Checks

--- a/.github/workflows/csr-generator.yml
+++ b/.github/workflows/csr-generator.yml
@@ -48,8 +48,6 @@ on:
         required: true
         type: string
 
-permissions: {}
-
 jobs:
   generate-csr:
     runs-on: ubuntu-latest

--- a/.github/workflows/csr-generator.yml
+++ b/.github/workflows/csr-generator.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Create or update CSR secret in OpenShift
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         env:
           OC_TOKEN: ${{ inputs.oc_token || secrets.oc_token }}
           OC_SERVER: ${{ inputs.oc_server }}

--- a/.github/workflows/csr-generator.yml
+++ b/.github/workflows/csr-generator.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Create or update CSR secret in OpenShift
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         env:
           OC_TOKEN: ${{ inputs.oc_token || secrets.oc_token }}
           OC_SERVER: ${{ inputs.oc_server }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,6 +44,7 @@ jobs:
   deploy-test:
     name: Deploy (test)
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/.deployer.yml
     secrets:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Create labeled ConfigMap
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify labeled resources are gone
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Create labeled ConfigMap
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify labeled resources are gone
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -61,6 +61,8 @@ jobs:
   deploy-db:
     name: Stack
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     outputs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
@@ -78,6 +80,7 @@ jobs:
     name: Deploys
     needs: [builds, deploy-db]
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/.deployer.yml
     secrets:
@@ -93,6 +96,7 @@ jobs:
     name: Cleanup
     needs: [deploys]
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/.pr-close.yml
     secrets: inherit
@@ -103,6 +107,8 @@ jobs:
 
   label-setup:
     name: Label Cleanup (setup)
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -129,6 +135,7 @@ jobs:
     name: Label Cleanup (cleanup)
     needs: [label-setup]
     permissions:
+      contents: read
       packages: write
     uses: ./.github/workflows/.pr-close.yml
     secrets: inherit
@@ -138,6 +145,8 @@ jobs:
   label-verify:
     name: Label Cleanup (verify)
     needs: [label-cleanup]
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -153,6 +162,8 @@ jobs:
 
   csr-generator: # testing, will be deleted
     name: Certificate Generation
+    permissions:
+      contents: read
     uses: ./.github/workflows/csr-generator.yml
     secrets:
       oc_namespace: ${{ secrets.oc_namespace }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Login to cluster and uninstall Helm releases
-        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
+        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Login to cluster and uninstall Helm releases
-        uses: bcgov/action-oc-runner@d2fc921aaa9d70684c186dbb7754e6985d44d86f # v1.4.1
+        uses: bcgov/action-oc-runner@fix/explicit-token-checkout
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}


### PR DESCRIPTION
## Summary

- Add `contents: read` to reusable-workflow jobs that invoke `bcgov/action-oc-runner` (and other actions doing implicit `actions/checkout` of the caller repo)
- Affected: `.pr-close.yml` (`cleanup`), `.deployer.yml` (`deploy`), `csr-generator.yml` (`generate-csr`)
- Unblocks private-repo consumers of these shared workflows

## Why

When a private repo consumes our reusable workflows, the chain looks like:

````
caller pr-close.yml (private repo)
  -> .pr-close.yml (this repo, permissions: {} at top)
    -> bcgov/action-oc-runner
      -> actions/checkout@v6  <- uses GITHUB_TOKEN
````

The affected jobs had no `permissions:` block of their own, so they inherited the workflow-level `permissions: {}` — an empty scope. The implicit `GITHUB_TOKEN` used by `actions/checkout` then has no `contents` scope and the checkout fails against a private caller repo.

Granting `contents: read` at the job level (the most reduced scope that still works) lets the implicit token authenticate, with no API changes to any downstream action and no token plumbing required.

## Scope

Only reusable workflows (`.pr-close.yml`, `.deployer.yml`) and `csr-generator.yml` (also reusable, also affected). `.pr-validate.yml` is fine — its chain uses Node actions that operate via the GitHub API with `pull-requests: write` (already granted). `.schema-spy.yml` is unaffected (out of scope per request).

Test/demo workflows in this repo (`pr-open.yml`, `merge.yml`, `schedule.yml`) are not consumed from private repos so they're not in scope.

## Test plan

- Existing test workflows (`pr-open.yml`, `merge.yml`) exercise the affected reusable workflows in this same repo on every PR/merge — CI green confirms no regression for the public-repo path
- Private-repo consumers (e.g. the user in #247) can re-run their `pr-close` workflow against this branch via `uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@fix/private-repo-permissions` to validate end-to-end before merge

Closes #247

---

Parallel PRs to make this work:
https://github.com/bcgov/action-oc-runner/pull/67
https://github.com/bcgov/action-get-pr/pull/37
https://github.com/bcgov/action-diff-triggers/pull/37

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-251-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-251-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)