### PR TITLE
build(deps): update action-oc-runner pin to v1.5.1

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -95,7 +95,7 @@ jobs:
       # Variables
       - if: inputs.tag  == ''
         id: pr
-        uses: bcgov/action-get-pr@bf6c85d0ed23a151f2829956c140fde87979bbf2 # v0.2.0
+        uses: bcgov/action-get-pr@8f9a16a1f7a7574b10e2fb473bfef0c4c4fff3d6 # v0.2.1
 
       - name: Vars
         id: vars

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -125,7 +125,7 @@ jobs:
       ### Deploy
       - name: Interrupt deployments (PR only)
         if: github.event_name == 'pull_request'
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/.pr-close.yml
+++ b/.github/workflows/.pr-close.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           release: ${{ inputs.repository }}-${{ inputs.target }}
         if: inputs.cleanup == 'helm'
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: OC Template (label) Cleanup
         if: inputs.cleanup == 'label'
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Remove PVCs
         if: inputs.remove_pvc
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/csr-generator.yml
+++ b/.github/workflows/csr-generator.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Create or update CSR secret in OpenShift
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         env:
           OC_TOKEN: ${{ inputs.oc_token || secrets.oc_token }}
           OC_SERVER: ${{ inputs.oc_server }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Create labeled ConfigMap
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify labeled resources are gone
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Login to cluster and uninstall Helm releases
-        uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 #v.1.5.0
+        uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
         with:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}


### PR DESCRIPTION
This PR updates the 'action-oc-runner' dependency pin to 'v1.5.1'.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-254-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-254-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)