### PR TITLE
fix(ci): catch results false positive

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -173,12 +173,13 @@ jobs:
       oc_server: ${{ vars.oc_server }}
 
   results:
+    if: always()
     name: Results
     needs: [builds, csr-generator, deploys, label-verify, schema-spy, validate]
     runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
-        run: echo "At least one job has failed." && exit 1
+        run: echo "At least one job has failed or was cancelled." && exit 1
 
       - if: needs.deploys.outputs.triggered == 'true'
         run: echo "Deploy triggered successfully!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -177,7 +177,7 @@ jobs:
     needs: [builds, csr-generator, deploys, label-verify, schema-spy, validate]
     runs-on: ubuntu-24.04
     steps:
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
         run: echo "At least one job has failed." && exit 1
 
       - if: needs.deploys.outputs.triggered == 'true'

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -172,20 +172,28 @@ jobs:
       domain: example.gov.bc.ca
       oc_server: ${{ vars.oc_server }}
 
+  # ==========================================================================
+  # WARNING: This job acts as the required merge gate for this workflow.
+  # If you add a new job to this workflow, you MUST add its ID to the 'needs'
+  # array below, otherwise its failure or cancellation will not block the PR!
+  # ==========================================================================
   results:
-    if: always()
     name: Results
     needs: [builds, csr-generator, deploys, label-verify, schema-spy, validate]
+    if: always()
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
-      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'cancelled')
-        run: echo "At least one job has failed or was cancelled." && exit 1
+      - name: Log Job Results Context
+        run: |
+          echo "=== Upstream Job Statuses ==="
+          echo '${{ toJson(needs) }}'
 
-      - if: needs.deploys.outputs.triggered == 'true'
-        run: echo "Deploy triggered successfully!"
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
+          exit 1
 
-      # - if: needs.deploys.outputs.triggered != 'true'
-      #   run: |
-      #     # Handle fail
-      #     echo "needs.deploys == ${{ toJson(needs.deploys) }}"
-      #     exit 1
+      - name: Success Message
+        run: echo "✅ All critical checks passed or were intentionally skipped!"


### PR DESCRIPTION
This PR corrects the spelling of 'cancelled' (with two 'l's) in GitHub Actions status check and log messages. This prevents false positive passes when job statuses are checked.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-258-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-258-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)