### PR TITLE
docs(readme): document openshift-reporter usage and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,33 @@ oc process -f openshift.deploy.yml -p ZONE=test -p TAG=test \
 # 6. Scale up stack or recreate deployments
 # Use web console, GitHub Actions workflow or cli
 ```
+
+# ./openshift-reporter
+
+`reporter.sh` - report on OpenShift user rights across accessible projects.
+
+## Usage
+
+### Direct Execution via curl
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash
+```
+
+To redirect output to a report file:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash > ~/Downloads/report.txt 2>&1
+```
+
+### Local Execution
+
+```bash
+./openshift-reporter/reporter.sh "admin edit view" > ~/Downloads/report.txt 2>&1
+```
+
+### Prerequisites
+
+- Active `oc` session (`oc whoami`)
+- `jq` CLI installed locally
+

--- a/README.md
+++ b/README.md
@@ -76,10 +76,16 @@ oc process -f openshift.deploy.yml -p ZONE=test -p TAG=test \
 curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash
 ```
 
+To pass arguments (e.g. custom roles):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash -s -- "admin edit"
+```
+
 To redirect output to a report file:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash > report.txt 2>&1
+curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash -s -- "admin edit view" > report.txt 2>&1
 ```
 
 ### Local Execution

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/
 To redirect output to a report file:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash > ~/Downloads/report.txt 2>&1
+curl -fsSL https://raw.githubusercontent.com/bcgov/quickstart-openshift-helpers/main/openshift-reporter/reporter.sh | bash > report.txt 2>&1
 ```
 
 ### Local Execution
 
 ```bash
-./openshift-reporter/reporter.sh "admin edit view" > ~/Downloads/report.txt 2>&1
+./openshift-reporter/reporter.sh "admin edit view" > report.txt 2>&1
 ```
 
 ### Prerequisites


### PR DESCRIPTION
Adds documentation for `openshift-reporter/reporter.sh` to `README.md`, covering `curl | bash` execution, local execution, output redirection, and prerequisites.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-271-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-271-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)