### PR TITLE
feat(oc_scripts): add TOC filtering, unprivileged restore, and collation guidance to db_transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 
 `rename_deployment.sh` - rename a deployment (metadata, labels)
 
-`db_transfer.sh` - stream pg_dump from one container to pg_restore in another
+`db_transfer.sh` - stream binary pg_dump from one container to pg_restore in another, with TOC filtering and `--no-owner --no-privileges`
 
 `db_compare.sh` - compare PostgreSQL table row counts between two deployments
 
@@ -37,9 +37,9 @@ jobs:
 
 These scripts can be used to migrate a postgres or postgis database.
 
-Note: Make sure your template deploys the correct db version.  PR-based pipelines, which we strongly recommend, often require a merge before custom images are re-labeled.
+Note: Make sure your template deploys the correct db version. PR-based pipelines, which we strongly recommend, often require a merge before custom images are re-labeled.
 
-```
+```bash
 # 1. Scale down or delete stack (non-db only)
 # Use web console or cli
 
@@ -57,10 +57,17 @@ Note: Make sure your template deploys the correct db version.  PR-based pipeline
 oc process -f openshift.deploy.yml -p ZONE=test -p TAG=test \
   | oc apply -f -
 
-# 5. Stream dump from old to new db
+# 5. Stream dump from old to new db (filters conflicting PostGIS extension objects and restores with --no-owner --no-privileges)
 ./db_transfer.sh your-db-prev your-db
 
-# 6. Scale up stack or recreate deployments
+# 6. Collation Refresh (PostgreSQL Major Upgrade / glibc update)
+# When upgrading PostgreSQL major versions, clear the collation version warning:
+# oc exec -it deployment/your-db -- psql -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c "ALTER DATABASE ${POSTGRES_DB} REFRESH COLLATION VERSION;"
+
+# 7. Compare row counts between source and target databases
+./db_compare.sh your-db-prev your-db
+
+# 8. Scale up stack or recreate deployments
 # Use web console, GitHub Actions workflow or cli
 ```
 

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -70,18 +70,39 @@ fi
 
 # Stream binary dump directly from old deployment to new deployment, filter TOC, and restore
 echo -e "\nDatabase transfer from '${SOURCE_DEPLOYMENT}' to '${TARGET_DEPLOYMENT}' beginning."
-oc exec -i deployment/"${SOURCE_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc ${DUMP_PARAMETERS}" \
-  | oc exec -i deployment/"${TARGET_DEPLOYMENT}" -- bash -c "
-    set -euo pipefail
-    trap 'rm -f /tmp/transfer.dump /tmp/transfer.list' EXIT
-    cat > /tmp/transfer.dump
-    if [[ -n \"${RESTORE_TOC_EXCLUDE}\" ]]; then
-      pg_restore -l /tmp/transfer.dump | grep -v -iE \"${RESTORE_TOC_EXCLUDE}\" > /tmp/transfer.list || true
-      pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} --no-owner --no-privileges -L /tmp/transfer.list /tmp/transfer.dump
-    else
-      pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} --no-owner --no-privileges /tmp/transfer.dump
+oc exec -i deployment/"${SOURCE_DEPLOYMENT}" -- env DUMP_PARAMETERS="${DUMP_PARAMETERS}" bash -c '
+  set -euo pipefail
+  pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -Fc ${DUMP_PARAMETERS}
+' | oc exec -i deployment/"${TARGET_DEPLOYMENT}" -- env RESTORE_TOC_EXCLUDE="${RESTORE_TOC_EXCLUDE}" bash -c '
+  set -euo pipefail
+  trap "rm -f /tmp/transfer.dump /tmp/transfer.list" EXIT
+  cat > /tmp/transfer.dump
+  if [[ -n "${RESTORE_TOC_EXCLUDE:-}" ]]; then
+    set +e
+    pg_restore -l /tmp/transfer.dump | grep -v -iE "${RESTORE_TOC_EXCLUDE}" > /tmp/transfer.list
+    pipe_status=("${PIPESTATUS[@]}")
+    set -e
+
+    if [[ ${pipe_status[0]} -ne 0 ]]; then
+      echo "Error: pg_restore failed to read TOC from dump file." >&2
+      exit "${pipe_status[0]}"
     fi
-  "
+
+    if [[ ${pipe_status[1]} -ge 2 ]]; then
+      echo "Error: grep failed with exit code ${pipe_status[1]} while filtering TOC." >&2
+      exit "${pipe_status[1]}"
+    fi
+
+    if [[ ! -s /tmp/transfer.list ]]; then
+      echo "Error: TOC list is empty after filtering with pattern \"${RESTORE_TOC_EXCLUDE}\"." >&2
+      exit 1
+    fi
+
+    pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --no-owner --no-privileges -L /tmp/transfer.list /tmp/transfer.dump
+  else
+    pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --no-owner --no-privileges /tmp/transfer.dump
+  fi
+'
 
 # Results
 echo -e "\nDatabase transfer from '${SOURCE_DEPLOYMENT}' to '${TARGET_DEPLOYMENT}' complete."

--- a/oc_scripts/db_transfer.sh
+++ b/oc_scripts/db_transfer.sh
@@ -15,19 +15,24 @@
 # - If the target database is not empty, you may see errors like "schema ... already exists".
 #   These are expected if objects already exist and can usually be ignored, but always review
 #   the output for unexpected or critical errors.
+# - TOC filtering is enabled by default to strip extension definitions (e.g. postgis_tiger_geocoder,
+#   postgis_topology) that conflict on restore. Override via RESTORE_TOC_EXCLUDE or set to "" to disable.
+# - Restores are executed with --no-owner --no-privileges for unprivileged OpenShift container compatibility.
 
 # Strict mode: exit on error, unset vars, or failed pipes
 set -euo pipefail
 
 # Usage
 if [[ $# -lt 2 ]]; then
-  grep -v '^#!' "$0" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
+  script_path="${BASH_SOURCE[0]:-$0}"
+  grep -v '^#!' "${script_path}" | awk '/^#/ { sub(/^# ?/, ""); print; next } NF==0 { exit }'
   exit 1
 fi
 
 SOURCE_DEPLOYMENT="${1}"
 TARGET_DEPLOYMENT="${2}"
 DUMP_PARAMETERS="${DUMP_PARAMETERS:---exclude-schema=tiger --exclude-schema=tiger_data --exclude-schema=topology}"
+RESTORE_TOC_EXCLUDE="${RESTORE_TOC_EXCLUDE:-postgis_tiger_geocoder|postgis_topology}"
 
 # Fail fast if pods aren't found
 if ! oc get po -l deployment="${SOURCE_DEPLOYMENT}" | grep -q .; then
@@ -63,10 +68,20 @@ else
   echo "Warning: Could not find PVCs for comparison. Proceeding without age check."
 fi
 
-# Stream dump directly from old deployment to new deployment
+# Stream binary dump directly from old deployment to new deployment, filter TOC, and restore
 echo -e "\nDatabase transfer from '${SOURCE_DEPLOYMENT}' to '${TARGET_DEPLOYMENT}' beginning."
 oc exec -i deployment/"${SOURCE_DEPLOYMENT}" -- bash -c "pg_dump -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc ${DUMP_PARAMETERS}" \
-  | oc exec -i deployment/"${TARGET_DEPLOYMENT}" -- bash -c "pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} -Fc"
+  | oc exec -i deployment/"${TARGET_DEPLOYMENT}" -- bash -c "
+    set -euo pipefail
+    trap 'rm -f /tmp/transfer.dump /tmp/transfer.list' EXIT
+    cat > /tmp/transfer.dump
+    if [[ -n \"${RESTORE_TOC_EXCLUDE}\" ]]; then
+      pg_restore -l /tmp/transfer.dump | grep -v -iE \"${RESTORE_TOC_EXCLUDE}\" > /tmp/transfer.list || true
+      pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} --no-owner --no-privileges -L /tmp/transfer.list /tmp/transfer.dump
+    else
+      pg_restore -U \${POSTGRES_USER} -d \${POSTGRES_DB} --no-owner --no-privileges /tmp/transfer.dump
+    fi
+  "
 
 # Results
 echo -e "\nDatabase transfer from '${SOURCE_DEPLOYMENT}' to '${TARGET_DEPLOYMENT}' complete."


### PR DESCRIPTION
### Summary of Changes

Imports the database migration improvements tested in `bcgov/nr-fom#1035` and adds portability enhancements:

1. **TOC Filtering & Selective Restore:**
   - Buffers the streamed dump to `/tmp/transfer.dump` inside the target pod.
   - Extracts the Table of Contents via `pg_restore -l` and filters out conflicting extension entries matching `RESTORE_TOC_EXCLUDE` (defaults to `postgis_tiger_geocoder|postgis_topology`).
   - Restores using `pg_restore -L /tmp/transfer.list`.
2. **Unprivileged & Cross-User Restores:**
   - Adds `--no-owner --no-privileges` to `pg_restore` to avoid permission and ownership failures across OpenShift container environments.
3. **Resilient Cleanup & Error Handling:**
   - Uses `trap 'rm -f /tmp/transfer.dump /tmp/transfer.list' EXIT` inside the target pod subshell under `set -euo pipefail` to guarantee cleanup regardless of success or failure.
4. **Documentation & Migration Guidance:**
   - Updates `README.md` to document the new behavior and notes the PostgreSQL major upgrade collation refresh command (`ALTER DATABASE ... REFRESH COLLATION VERSION;`).

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-helpers-278-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-helpers-278-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift-helpers/actions/workflows/merge.yml)